### PR TITLE
Syntax fix

### DIFF
--- a/robot-arm.py
+++ b/robot-arm.py
@@ -312,8 +312,8 @@ for event in gamepad.read_loop():   #this loops infinitely
             grabber_open = True
             grabber_close = False
 
-    if event.type == 1 and event.code == 314 and event.value == 1:  #Share
-        #Demo
+    # if event.type == 1 and event.code == 314 and event.value == 1:  #Share
+    #     #Demo
 
     if event.type == 1 and event.code == 315 and event.value == 1:  #Options
         #Reset


### PR DESCRIPTION
Hi there,

I'm in the process of getting your awesome ev3 robotic arm to work and found a small syntax error in the code. As far as I know an empty if statement is not valid:

robot@ev3dev:~/ev3robotarm$ cat main.py.err.log
File "/home/robot/ev3robotarm/main.py", line 318
if event.type == 1 and event.code == 315 and event.value == 1: #Options
^
IndentationError: expected an indented block

This pull request fixes that issue.

Great work on the MOC!

Kind regards,

Marno